### PR TITLE
feat: added ability to register directive with code content using config object

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,10 @@ All of parameters groups – `[]`, `()`, `{}` – are optional, but their order 
 
 - `registerContainerDirective()` – register handler for new container block or configure it using config-object.
   ```ts
-  function registerContainerDirective(md: MarkdownIt, config: ContainerDirectiveConfig): void;
+  function registerContainerDirective(
+    md: MarkdownIt,
+    config: ContainerDirectiveConfig | CodeContainerDirectiveConfig,
+  ): void;
   function registerContainerDirective(
     md: MarkdownIt,
     name: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,7 +65,8 @@ type TokensDesc = {
 
 export type ContainerDirectiveConfig = {
     name: string;
-    match: (params: LeafBlockDirectiveParams, state: StateBlock) => boolean;
+    type?: 'container_block';
+    match: (params: ContainerDirectiveParams, state: StateBlock) => boolean;
     container: TokensDesc;
     inlineContent?: TokensDesc & {
         /** @default true */
@@ -76,8 +77,15 @@ export type ContainerDirectiveConfig = {
     contentTokenizer?: (
         state: StateBlock,
         content: BlockContent,
-        params: LeafBlockDirectiveParams,
+        params: ContainerDirectiveParams,
     ) => void;
+};
+
+export type CodeContainerDirectiveConfig = {
+    name: string;
+    type: 'code_block';
+    match: (params: ContainerDirectiveParams, state: StateBlock) => boolean;
+    container: TokensDesc;
 };
 
 export interface MdItWithHandlers extends MarkdownIt {

--- a/tests/src/__snapshots__/directive.test.ts.snap
+++ b/tests/src/__snapshots__/directive.test.ts.snap
@@ -1,5 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Directive block with content should add code container handler via config 1`] = `
+[
+  Token {
+    "attrs": [
+      [
+        "class",
+        "code-js",
+      ],
+    ],
+    "block": true,
+    "children": null,
+    "content": "(function(window) {
+window.alert('Hello world!');
+})(window);
+",
+    "hidden": false,
+    "info": "js",
+    "level": 0,
+    "map": [
+      2,
+      7,
+    ],
+    "markup": ":::",
+    "meta": null,
+    "nesting": 0,
+    "tag": "code",
+    "type": "code_js",
+  },
+]
+`;
+
 exports[`Directive helpers createBlockInlineToken should parse inline content in block diagram 1`] = `
 [
   Token {

--- a/tests/src/directive.test.ts
+++ b/tests/src/directive.test.ts
@@ -388,6 +388,33 @@ describe('Directive', () => {
                 startLine: 0,
             });
         });
+
+        it('should add code container handler via config', () => {
+            const md = new MarkdownIt().use(directiveParser());
+            registerContainerDirective(md, {
+                name: 'js',
+                type: 'code_block',
+                match: () => true,
+                container: {
+                    token: 'code_js',
+                    tag: 'code',
+                    attrs: {class: 'code-js'},
+                },
+            });
+            const tokens = md.parse(
+                dd`
+
+
+                :::js
+                (function(window) {
+                window.alert('Hello world!');
+                })(window);
+                :::
+                `,
+                {},
+            );
+            expect(tokens).toMatchSnapshot();
+        });
     });
 
     describe('helpers', () => {


### PR DESCRIPTION
Example:
```js
registerContainerDirective(md, {
  name: 'js',
  type: 'code_block',
  match: () => true,
  container: {
    token: 'code_js',
    tag: 'code',
    attrs: {class: 'code-js'},
  },
});
```

Produces token similar to token for fence block:
```js
Token {
  "attrs": [["class","code-js"]],
  "block": true,
  "children": null,
  "content": "...",
  "hidden": false,
  "info": "js",
  "level": 0,
  "map": [number, number],
  "markup": ":::",
  "meta": null,
  "nesting": 0,
  "tag": "code",
  "type": "code_js",
}
```