### PR TITLE
feat: enable inline directives by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,6 @@ All of parameters groups – `[]`, `()`, `{}` – are optional, but their order 
 - `()` – used for something like required identifier (id, url, etc.);
 - `{}` – used to pass optional named arguments / attributes / `key=value` pairs.
 
-> Note: inline directives disabled by default. You can enable them using `enableInlineDirectives()` helper.
-
 ## Helpers
 
 ### Enable or disable some of directive types

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,6 @@ import type MarkdownIt from 'markdown-it';
 
 import directivePlugin from 'markdown-it-directive';
 
-import {disableInlineDirectives} from './helpers';
-
 export {
     enableBlockDirectives,
     enableInlineDirectives,
@@ -33,18 +31,8 @@ export type {
     InlineDirectiveHandler,
 } from './types';
 
-// eslint-disable-next-line valid-jsdoc
-/**
- * Inline directives are disabled by default.
- *
- * They will be enabled after this error is fixed: https://github.com/hilookas/markdown-it-directive/issues/5
- *
- * To enable inline directives use `enableInlineDirectives()` helper.
- */
 export const directiveParser = (): MarkdownIt.PluginSimple => {
     return (md) => {
         directivePlugin(md);
-
-        disableInlineDirectives(md);
     };
 };

--- a/tests/src/directive.test.ts
+++ b/tests/src/directive.test.ts
@@ -10,7 +10,6 @@ import {
     directiveParser,
     disableBlockDirectives,
     disableInlineDirectives,
-    enableInlineDirectives,
     registerContainerDirective,
     registerInlineDirective,
     registerLeafBlockDirective,
@@ -20,14 +19,14 @@ import {
 
 const html = (text: string, {plugins}: {plugins?: MarkdownIt.PluginSimple[]} = {}) => {
     const {result} = transform(text, {
-        plugins: [directiveParser(), enableInlineDirectives, ...(plugins || [])],
+        plugins: [directiveParser(), ...(plugins || [])],
     });
 
     return result.html;
 };
 
 describe('Directive', () => {
-    it('should not parse inline directive by default', () => {
+    it.skip('should not parse inline directive by default', () => {
         const md = new MarkdownIt().use(directiveParser());
         const inlineHandler = jest.fn(() => false);
         const leafHandler = jest.fn(() => false);
@@ -518,7 +517,7 @@ describe('Directive', () => {
 
         describe('tokenizeInlineContent', () => {
             it('should parse content in inline directive', () => {
-                const md = new MarkdownIt().use(directiveParser()).use(enableInlineDirectives);
+                const md = new MarkdownIt().use(directiveParser());
                 registerInlineDirective(md, 'inl', (state, params) => {
                     if (!params.content) {
                         return false;


### PR DESCRIPTION
Because runtime error has been fixed, and `markdown-it-directive` has been updated to latest version. As a result, there is no reason not to use inline directives.