### PR TITLE
fix: added safeguard newline for reliable parsing

### DIFF
--- a/src/helpers/registrars.ts
+++ b/src/helpers/registrars.ts
@@ -181,7 +181,7 @@ function buildCodeContainerHandler(
         // set fields like for fence token
         token.map = [params.startLine, params.endLine];
         token.content = params.content.raw;
-        token.markup = ':::';
+        token.markup = ':::\n';
         token.info = name;
 
         if (container.attrs) {


### PR DESCRIPTION
In response to the issue described in https://github.com/hilookas/markdown-it-directive/pull/10, a safeguard newline `:::\n` was added to ensure more reliable parsing of block directives until the directive package fix is released.