### PR TITLE
feat: added ability to register leaf-block directive using config object

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ All of parameters groups – `[]`, `()`, `{}` – are optional, but their order 
 - `registerLeafBlockDirective()` – register handler for new leaf block directive.
 
   ```ts
+  function registerLeafBlockDirective(md: MarkdownIt, config: LeafBlockDirectiveConfig): void;
   function registerLeafBlockDirective(
     md: MarkdownIt,
     name: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,8 +22,10 @@ export {
 export type {
     DirectiveAttrs,
     DirectiveDests,
+    LeafBlockDirectiveConfig,
     LeafBlockDirectiveParams,
     LeafBlockDirectiveHandler,
+    CodeContainerDirectiveConfig,
     ContainerDirectiveConfig,
     ContainerDirectiveParams,
     ContainerDirectiveHandler,

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,12 @@ export type TokensDesc<P> = {
     meta?: object | ((params: P) => object);
 };
 
+export type LeafBlockDirectiveConfig = {
+    name: string;
+    match: (params: LeafBlockDirectiveParams, state: StateBlock) => boolean;
+    container: TokensDesc<LeafBlockDirectiveParams>;
+};
+
 export type ContainerDirectiveConfig = {
     name: string;
     type?: 'container_block';

--- a/tests/src/__snapshots__/directive.test.ts.snap
+++ b/tests/src/__snapshots__/directive.test.ts.snap
@@ -976,3 +976,34 @@ exports[`Directive inline should parse inline content, dests and attrs in inline
   "startPos": 12,
 }
 `;
+
+exports[`Directive leaf block should add handler via config 1`] = `
+[
+  Token {
+    "attrs": [
+      [
+        "data-block",
+        "2",
+      ],
+    ],
+    "block": true,
+    "children": null,
+    "content": "",
+    "hidden": false,
+    "info": "",
+    "level": 0,
+    "map": [
+      2,
+      3,
+    ],
+    "markup": "::blck",
+    "meta": {
+      "data": "2",
+      "leaf": true,
+    },
+    "nesting": 0,
+    "tag": "div",
+    "type": "leaf-block",
+  },
+]
+`;

--- a/tests/src/directive.test.ts
+++ b/tests/src/directive.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import MarkdownIt from 'markdown-it';
 import transform from '@diplodoc/transform';
 import dd from 'ts-dedent';
@@ -253,6 +254,29 @@ describe('Directive', () => {
                 },
                 startLine: 0,
             });
+        });
+
+        it('should add handler via config', () => {
+            const md = new MarkdownIt().use(directiveParser());
+            registerLeafBlockDirective(md, {
+                name: 'blck',
+                match: ({attrs}) => Boolean(attrs?.['data-block']),
+                container: {
+                    token: 'leaf-block',
+                    tag: 'div',
+                    attrs: ({attrs}) => ({'data-block': attrs!['data-block']}),
+                    meta: ({attrs}) => ({leaf: true, data: attrs!['data-block']}),
+                },
+            });
+            const tokens = md.parse(
+                dd`
+
+
+                :: blck {data-block=2}
+                `,
+                {},
+            );
+            expect(tokens).toMatchSnapshot();
         });
     });
 


### PR DESCRIPTION
Example:
```js
registerLeafBlockDirective(md, {
    name: 'block',
    match: () => true,
    container: {
        token: 'leaf-block',
        tag: 'div',
        attrs: ({attrs}) => attrs || {},
        meta: {leaf: true},
    },
});
```