### PR TITLE
fix(block): fix lheading at first content line breaks directive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
-        "markdown-it-directive": "2.0.5"
+        "markdown-it-directive": "^2.0.6"
       },
       "devDependencies": {
         "@diplodoc/lint": "^1.2.0",
@@ -4938,9 +4938,9 @@
       }
     },
     "node_modules/markdown-it-directive": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/markdown-it-directive/-/markdown-it-directive-2.0.5.tgz",
-      "integrity": "sha512-hpLYmcVeKR6hbXRK3OlJm4oVaFaBJg6JQ5E7j5Xo7K3QbTMbMqeLXvHdAr1MDIe3iNogJNamTaNycjkOUJg7cg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/markdown-it-directive/-/markdown-it-directive-2.0.6.tgz",
+      "integrity": "sha512-yTjIan0I3LRMooa9uPNTs1DlcNVx/NqRjrEd3eipe286I8t3z+xzSSstrQ3OGDmKJkDSjg0rShO1t3uMN04U3Q==",
       "peerDependencies": {
         "@types/markdown-it": "^12.0.0 || ^13.0.0",
         "markdown-it": "^12.0.0 || ^13.0.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "markdown-it-directive": "2.0.5"
+    "markdown-it-directive": "^2.0.6"
   },
   "devDependencies": {
     "@diplodoc/lint": "^1.2.0",

--- a/tests/src/directive.test.ts
+++ b/tests/src/directive.test.ts
@@ -449,6 +449,54 @@ describe('Directive', () => {
             );
             expect(tokens).toMatchSnapshot();
         });
+
+        it('should parse directive with "-" at first content line', () => {
+            const handler = jest.fn(() => false);
+            html(
+                dd`
+                :::block
+                -
+                :::
+                `,
+                {plugins: [(md) => registerContainerDirective(md, 'block', handler)]},
+            );
+
+            expect(handler).toHaveBeenCalledTimes(1);
+            // @ts-expect-error
+            expect(handler.mock.calls[0][1]).toStrictEqual({
+                content: {
+                    endLine: 2,
+                    raw: '-\n',
+                    startLine: 1,
+                },
+                endLine: 3,
+                startLine: 0,
+            });
+        });
+
+        it('should parse directive with "=" at first content line', () => {
+            const handler = jest.fn(() => false);
+            html(
+                dd`
+                :::block
+                =
+                :::
+                `,
+                {plugins: [(md) => registerContainerDirective(md, 'block', handler)]},
+            );
+
+            expect(handler).toHaveBeenCalledTimes(1);
+            // @ts-expect-error
+            expect(handler.mock.calls[0][1]).toStrictEqual({
+                content: {
+                    endLine: 2,
+                    raw: '=\n',
+                    startLine: 1,
+                },
+                endLine: 3,
+                startLine: 0,
+            });
+        });
     });
 
     describe('helpers', () => {


### PR DESCRIPTION
Fixed an issue where an lheading immediately following an opening directive would take higher precedence and break the directive.

```
:::block
-
:::
```
was rendered to

```
<h2>:::block</h2>
<p>:::</p>
```